### PR TITLE
Make array-record build on aarch64

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -131,9 +131,9 @@ http_archive(
 http_archive(
     name = "highwayhash",
     build_file = "@com_google_riegeli//third_party:highwayhash.BUILD",
-    sha256 = "cf891e024699c82aabce528a024adbe16e529f2b4e57f954455e0bf53efae585",
-    strip_prefix = "highwayhash-276dd7b4b6d330e4734b756e97ccfb1b69cc2e12",
-    urls = ["https://github.com/google/highwayhash/archive/276dd7b4b6d330e4734b756e97ccfb1b69cc2e12.zip"],  # 2019-02-22
+    sha256 = "5380cb7cf19e7c9591f31792b7794d48084f6a3ab7c03d637cd6a32cf2ee8686",
+    strip_prefix = "highwayhash-a7f68e2f95fac08b24327d74747521cf634d5aff",
+    urls = ["https://github.com/google/highwayhash/archive/a7f68e2f95fac08b24327d74747521cf634d5aff.zip"],  # 2019-02-22
 )
 
 # Tensorflow, 20230130

--- a/oss/build_whl.sh
+++ b/oss/build_whl.sh
@@ -3,12 +3,13 @@
 
 set -e -x
 
-export PYTHON_VERSION="${PYTHON_VERSION}"
+export PYTHON_VERSION=3
 PYTHON="python${PYTHON_VERSION}"
 PYTHON_MAJOR_VERSION=$(${PYTHON} -c 'import sys; print(sys.version_info.major)')
 PYTHON_MINOR_VERSION=$(${PYTHON} -c 'import sys; print(sys.version_info.minor)')
-BAZEL_FLAGS="--crosstool_top="
-BAZEL_FLAGS+="@sigbuild-r2.9-${PYTHON}_config_cuda//crosstool:toolchain"
+#BAZEL_FLAGS="--crosstool_top="
+#BAZEL_FLAGS+="@sigbuild-r2.9-${PYTHON}_config_cuda//crosstool:toolchain"
+BAZEL_FLAGS="--sandbox_debug --verbose_failures "
 
 function write_to_bazelrc() {
   echo "$1" >> .bazelrc
@@ -63,7 +64,7 @@ function main() {
   ${PYTHON} setup.py bdist_wheel --python-tag py3${PYTHON_MINOR_VERSION}
 
   echo $(date) : "=== Auditing wheel"
-  auditwheel repair --plat manylinux2014_x86_64 -w dist dist/*.whl
+  auditwheel repair --plat linux_aarch64 -w dist dist/*.whl
   echo $(date) : "=== Listing wheel"
   ls -lrt dist/*.whl
   cp dist/*.whl "${DEST}"

--- a/python/BUILD
+++ b/python/BUILD
@@ -34,9 +34,9 @@ py_library(
     srcs = ["array_record_data_source.py"],
     data = [":array_record_module.so"],
     deps = [
-        "//pyglib:gfile",
+#        "//pyglib:gfile",
         # Implicit etils (/epath) dependency.
-        "//third_party/py/grain/google/ntk/array_record/python:fast_array_record",
+#        "//third_party/py/grain/google/ntk/array_record/python:fast_array_record",
     ],
 )
 
@@ -51,8 +51,8 @@ py_test(
     ],
     deps = [
         ":array_record_data_source",
-        "//third_party/py/grain/google/ntk/array_record/python:fast_array_record",
-        "//third_party/py/numpy",
+#        "//third_party/py/grain/google/ntk/array_record/python:fast_array_record",
+#        "//third_party/py/numpy",
         "@com_google_absl_py//absl/testing:absltest",
         "@com_google_absl_py//absl/testing:flagsaver",
         "@com_google_absl_py//absl/testing:parameterized",

--- a/python/array_record_data_source.py
+++ b/python/array_record_data_source.py
@@ -41,6 +41,7 @@ import pathlib
 import re
 import typing
 from typing import Any, Callable, List, Mapping, Protocol, Sequence, SupportsIndex, Tuple, TypeVar, Union
+import array_record.python.array_record_module as array_record_module
 
 from absl import flags
 from absl import logging
@@ -156,7 +157,7 @@ def _get_read_instructions(
       end = int(m.group(3))
     else:
       path = os.fspath(path)
-      reader = array_record.ArrayRecordReader(path)
+      reader = array_record_module.ArrayRecordReader(path)
       start = 0  # Using whole file.
       end = reader.num_records()
       reader.close()
@@ -173,7 +174,7 @@ def _get_read_instructions(
 
 def _create_reader(filename: epath.PathLike):
   """Returns an ArrayRecordReader for the given filename."""
-  return array_record.ArrayRecordReader(
+  return array_record_module.ArrayRecordReader(
       filename,
       options="readahead_buffer_size:0",
       file_reader_buffer_size=32768,
@@ -181,7 +182,7 @@ def _create_reader(filename: epath.PathLike):
 
 
 def _check_group_size(
-    filename: epath.PathLike, reader: array_record.ArrayRecordReader
+    filename: epath.PathLike, reader: array_record_module.ArrayRecordReader
 ) -> None:
   """Logs an error if the group size of the underlying file is not 1."""
   options = reader.writer_options_string()


### PR DESCRIPTION
In the absence of an Aarch64 wheel (see #71), this helps building from source

- upgrade highwayhash: the previous revision was 4y ago, there has been quite a few fixes since then.

- python/BUILD does not seem properly handle by copybara, it refers multiple paths inside google3 apparently.

- python/array_record_data_source.py does not include array_record but is using it. Maybe some other copybara problem?


One more problem left somehow is that running `bazel test ` isn't hermetic: the python test will prefer to import array_record from the environment installation (system or pip) instead of the local repo.