### PR TITLE
Ensure num_records is positive to avoid division by zero.

### DIFF
--- a/cpp/array_record_reader.cc
+++ b/cpp/array_record_reader.cc
@@ -281,8 +281,13 @@ void ArrayRecordReaderBase::Initialize() {
         return;
       }
       if (i == 0) {
-        // Detect group size from first footer. This should match the group_size
-        // in writer options but writer_options is not always available.
+        // Detect group size from first footer (must be a positive integer).
+        // This should match the group_size in writer options but writer_options
+        // is not always available.
+        if (footer.num_records() == 0) {
+          Fail(InvalidArgumentError("Invalid footer: num_records must be positive"));
+          return;
+        }
         state_->record_group_size = footer.num_records();
       }
       state_->chunk_offsets.push_back(footer.chunk_offset());


### PR DESCRIPTION
ReadRecord() divides chunk_idx by state_->chunk_group_size which is set to num_records of the first footer. A malformed input can lead to a division by zero. This check prevents that and fails with an error message instead.