### PR TITLE
fix an import issue

### DIFF
--- a/beam/arrayrecordio.py
+++ b/beam/arrayrecordio.py
@@ -7,7 +7,7 @@ from apache_beam import io
 from apache_beam import transforms
 from apache_beam.coders import coders
 from apache_beam.io import filebasedsink
-from apache_beam.io.filesystem.CompressionTypes import AUTO
+from apache_beam.io.filesystem import CompressionTypes
 from array_record.python.array_record_module import ArrayRecordWriter
 
 
@@ -21,7 +21,7 @@ class _ArrayRecordSink(filebasedsink.FileBasedSink):
       num_shards=0,
       shard_name_template=None,
       coder=coders.ToBytesCoder(),
-      compression_type=AUTO):
+      compression_type=CompressionTypes.AUTO):
 
     super().__init__(
         file_path_prefix,
@@ -53,7 +53,7 @@ class WriteToArrayRecord(transforms.PTransform):
       num_shards=0,
       shard_name_template=None,
       coder=coders.ToBytesCoder(),
-      compression_type=AUTO):
+      compression_type=CompressionTypes.AUTO):
 
     self._sink = _ArrayRecordSink(
         file_path_prefix,


### PR DESCRIPTION
Python complains that:

```
  File "{...}/.venv/lib/python3.12/site-packages/array_record/beam/arrayrecordio.py", line 10, in <module>
    from apache_beam.io.filesystem.CompressionTypes import AUTO
ModuleNotFoundError: No module named 'apache_beam.io.filesystem.CompressionTypes'; 'apache_beam.io.filesystem' is not a package
```

[and indeed it's not](https://github.com/apache/beam/blob/master/sdks/python/apache_beam/io/filesystem.py#L74).