### PR TITLE
Update `protobuf` and related deps; fix macOS symbol conflicts with TensorFlow.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,16 +25,10 @@ bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_python", version = "1.6.0")
 bazel_dep(name = "platforms", version = "0.0.11")
 
-# We force the protobuf version to be 28.3 because 29.x (that is required by rules_python) causes
-# segfault when importing TensorFlow due to a conflict with TF's protobuf version.
-bazel_dep(name = "protobuf", version = "29.0-rc3")
-single_version_override(
-    module_name = "protobuf",
-    version = "28.3",
-)
+bazel_dep(name = "protobuf", version = "33.1")
 
-bazel_dep(name = "googletest", version = "1.15.2")
-bazel_dep(name = "abseil-cpp", version = "20250127.1")
+bazel_dep(name = "googletest", version = "1.17.0")
+bazel_dep(name = "abseil-cpp", version = "20250512.1")
 bazel_dep(name = "abseil-py", version = "2.1.0")
 bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
 bazel_dep(name = "riegeli", version = "0.0.0-20250717-5b2e77e")

--- a/cpp/sequenced_chunk_writer.cc
+++ b/cpp/sequenced_chunk_writer.cc
@@ -119,7 +119,6 @@ void SequencedChunkWriterBase::TrySubmitFirstFutureChunk(
   }
   if (pad_to_block_boundary_) {
     if (!chunk_writer->PadToBlockBoundary()) {
-    {
       Fail(riegeli::Annotate(
           chunk_writer->status(),
           absl::StrFormat("Could not pad boundary for chunk: %d",

--- a/oss/build_whl.sh
+++ b/oss/build_whl.sh
@@ -32,6 +32,11 @@ function main() {
   write_to_bazelrc "build --cxxopt=-Wno-deprecated-declarations --host_cxxopt=-Wno-deprecated-declarations"
   write_to_bazelrc "build --cxxopt=-Wno-parentheses --host_cxxopt=-Wno-parentheses"
   write_to_bazelrc "build --cxxopt=-Wno-sign-compare --host_cxxopt=-Wno-sign-compare"
+  # Set -fvisbility=hidden to prevent symbol collision with TensorFlow on macOS
+  if [ "$(uname)" = "Darwin" ]; then
+    write_to_bazelrc "build --copt=-fvisibility=hidden"
+    write_to_bazelrc "build --copt=-fvisibility-inlines-hidden"
+  fi
 
   PLATFORM="$(uname)"
 

--- a/python/BUILD
+++ b/python/BUILD
@@ -2,6 +2,7 @@
 
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
 load("@pypi//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,6 +11,14 @@ licenses(["notice"])
 pybind_extension(
     name = "array_record_module",
     srcs = ["array_record_module.cc"],
+    linkopts = select({
+        "@platforms//os:macos": ["-Wl,-exported_symbols_list,$(location :exported_symbols_mac.lds)"],
+        "//conditions:default": [],
+    }),
+    additional_linker_inputs = select({
+        "@platforms//os:macos": [":exported_symbols_mac.lds"],
+        "//conditions:default": [],
+    }),
     deps = [
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/strings",

--- a/python/exported_symbols_mac.lds
+++ b/python/exported_symbols_mac.lds
@@ -1,0 +1,1 @@
+_PyInit_array_record_module


### PR DESCRIPTION
Update `protobuf` to match the version in `tensorflow>=2.21`; also fix dependency resolution by updating `googletest` and `abseil-cpp`.

Hide symbols generated by `array-record` to avoid segfaults in `test_import_tensorflow.py`